### PR TITLE
インスタンス一覧の改善

### DIFF
--- a/src/en/instances.md
+++ b/src/en/instances.md
@@ -1,6 +1,8 @@
 # List of instances
-::: warning
-Sorry, this page has not been translated yet. An english site with a list of instances can be found on [join.misskey.page](https://join.misskey.page/).
+::: tip
+If you would like to list your instance, please feel free to contact us via [Discord](https://discord.gg/Wp8gVStHW3) or other means.
 :::
 
 <MkInstances/>
+
+Alternatively, you can find an instance from the [auto-generated list of instances](https://join.misskey.page/en-US/instances).

--- a/src/instances.json5
+++ b/src/instances.json5
@@ -2,9 +2,6 @@
 	host: 'misskey.io',
 	lang: 'ja',
 }, {
-	host: 'gorf.space',
-	lang: 'en',
-}, {
 	host: 'sushi.ski',
 	name: 'すしすき～',
 	lang: 'ja',
@@ -12,4 +9,7 @@
 	host: 'newskey.cc',
 	name: '𝙉𝙚𝙬𝙨𝙠𝙚𝙮.𝙘𝙘',
 	lang: 'ja',
-},]
+},{
+	host: 'gorf.space',
+	lang: 'en',
+}, ]

--- a/src/instances.md
+++ b/src/instances.md
@@ -4,3 +4,5 @@
 :::
 
 <MkInstances/>
+
+または、[自動生成されたインスタンス一覧](https://join.misskey.page/ja-JP/instances) からインスタンスを探すこともできます。


### PR DESCRIPTION
- バージョンが古く埋め込みがうまくできていない`gorf.space`を下に表示
- まだまだ掲載インスタンスが少ないので joinmisskey のリンクを追加