### PR TITLE
Remove gorf.space from instance list 

### DIFF
--- a/src/instances.json5
+++ b/src/instances.json5
@@ -14,9 +14,6 @@
 	name: 'ThoseFewCalculators',
 	lang: 'en',
 }, {
-	host: 'gorf.space',
-	lang: 'en',
-}, {
 	host: 'mk.nixnet.social',
 	name: 'NixNet Social',
 	lang: 'en',

--- a/src/instances.json5
+++ b/src/instances.json5
@@ -9,7 +9,11 @@
 	host: 'newskey.cc',
 	name: '𝙉𝙚𝙬𝙨𝙠𝙚𝙮.𝙘𝙘',
 	lang: 'ja',
-},{
+}, {
+	host: 'stop.voring.me',
+	name: 'ThoseFewCalculators',
+	lang: 'en',
+}, {
 	host: 'gorf.space',
 	lang: 'en',
 }, ]


### PR DESCRIPTION
Their instance is very outdated and unused, and their preview is broken. 

![Screenshot_20220429-220613_1](https://user-images.githubusercontent.com/44733677/166094434-3571b676-a1d2-4317-90c8-abf4a1f9854a.png)
