### PR TITLE
Hide the link to PluginStore

### DIFF
--- a/src/.vuepress/config.ts
+++ b/src/.vuepress/config.ts
@@ -58,7 +58,6 @@ export default defineUserConfig<DefaultThemeOptions>({
 					text: 'お楽しみ',
 					children: [
 						'/instances',
-						'/plugins/',
 						'/appendix/assets'
 					]
 				}, {
@@ -168,7 +167,6 @@ export default defineUserConfig<DefaultThemeOptions>({
 					text: 'Taking part',
 					children: [
 						'/en/instances',
-						'/en/plugins/',
 						'/en/appendix/assets'
 					]
 				}, {


### PR DESCRIPTION
Related to https://github.com/misskey-dev/misskey-hub/issues/2#issuecomment-1120226762

Under the current circumstances, even if someone submits a plugin in Plugin Store, Syuilo and collaborators don't have the time to review it. I want to remove the link to Plugin Store while its page only exists. In the future, when Syuilo and collaborators can afford to do that, we will reopen the plugin store to the public.