### PR TITLE
Translate "Launch with OpenRC" in Japanese

### DIFF
--- a/src/docs/install/manual.md
+++ b/src/docs/install/manual.md
@@ -133,6 +133,55 @@ systemctl start misskey
 :::
 ::::
 
+:::: details OpenRCを用いた管理
+
+OpenRCサービスのファイルを作成
+
+`/etc/init.d/misskey`
+
+エディタで開き、以下のコードを貼り付けて保存:
+
+``` ini
+#!/sbin/openrc-run
+
+name=misskey
+description="Misskey daemon"
+
+command="/usr/bin/npm"
+command_args="start"
+command_user="misskey"
+
+supervisor="supervise-daemon"
+supervise_daemon_args=" -d /home/misskey/misskey -e NODE_ENV=\"production\""
+
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+  need net
+  use logger
+
+  # alternatively, uncomment if using nginx reverse proxy
+  #use logger nginx
+}
+```
+
+ブート時にmisskeyサービスが起動するように設定します
+
+```sh
+rc-update add misskey
+```
+
+misskeyサービスの起動
+
+```sh
+rc-service misskey start
+```
+
+::: tip
+`rc-service misskey status`と入力すると、サービスの状態を調べることができます。
+:::
+::::
+
 ## Misskeyのアップデート方法
 ::: warning
 アップデートの際は必ず[リリースノート](https://github.com/misskey-dev/misskey/blob/master/CHANGELOG.md)を確認し、変更点や追加で必要になる作業の有無(ほとんどの場合ありません)を予め把握するようにしてください。


### PR DESCRIPTION
「Misskeyインスタンスの作成」の選択肢の一つ「全部自力でインストール」内に、「OpenRCを用いた管理」を翻訳の上、追加しました。原文は以下のURLの通りで、翻訳後に日本語版「全部自力でインストール」の書き方（「:::: details」とか「```sh」など）に沿う形に合わせるため、少し編集しました。

原文：
https://misskey-hub.net/en/docs/install/manual.html#launch-with-openrc