### PR TITLE
italian language support for home routing

### DIFF
--- a/src/.vuepress/mitheme/src/client/layouts/Landing.vue
+++ b/src/.vuepress/mitheme/src/client/layouts/Landing.vue
@@ -241,8 +241,12 @@ let particleEnabled = ref(true);
 
 onMounted(() => {
 	const lang = navigator.language.toLowerCase();
-	if (location.pathname === '/' && !lang.startsWith('ja')) {
-		location.href = '/en';
+	if (location.pathname === '/' && lang.startsWith('it')) {
+		location.href  = '/it/';
+	} else {
+		if (location.pathname === '/' && !lang.startsWith('ja')) {
+			location.href = '/en/';
+		}
 	}
 
 	window.setTimeout(() => {


### PR DESCRIPTION
I've routed overseas languages with trailing slash  `/en/` `/it/` so that header menu gets instantly translated too