### PR TITLE
git cloneに--recurse-submodulesオプションをつける

### DIFF
--- a/src/docs/install/ubuntu-manual.md
+++ b/src/docs/install/ubuntu-manual.md
@@ -297,7 +297,7 @@ misskeyユーザーに変更。
 
 Gitでファイル類を展開。
 
-    git clone -b master https://github.com/misskey-dev/misskey.git
+    git clone -b master https://github.com/misskey-dev/misskey.git --recurse-submodules
 
     cd misskey
 


### PR DESCRIPTION
Ubuntu版Misskeyインストール方法詳説の通り進めるとsubmoduleが存在せずエラーを吐くので、git cloneコマンドの時点でsubmoduleを取得するようにしました。