### PR TITLE
日本語と英語の文章の不一致を解消

### DIFF
--- a/src/blog/2023-02-08-contribute-to-earn.md
+++ b/src/blog/2023-02-08-contribute-to-earn.md
@@ -54,7 +54,7 @@ You will receive all of the following rewards if you report vulnerabilities to u
 
 ## バックエンドのメモリリーク解消で2万円程度進呈 / Eliminate Memory Leaks in the Backend
 バックエンドのメモリリークを解消すると、2万円程度進呈します。  
-You will receive 10000JPY when you can eliminate memory leaks in the backend.
+You will receive 20000JPY when you can eliminate memory leaks in the backend.
 
 ## フロントエンドのメモリリーク解消で2万円程度進呈 / Eliminate Memory Leaks in the Frontend
 フロントエンドのメモリリークを解消すると、2万円程度進呈します。  


### PR DESCRIPTION
[#c661c00](https://github.com/misskey-dev/misskey-hub/commit/dbd7be4e4f9067586b9dde3f96a93629e7acaba7)で日本語と英語で金額が異なっていたため修正しました。