### PR TITLE
Reference to correct config template (Docker)

### DIFF
--- a/src/en/docs/install/docker.md
+++ b/src/en/docs/install/docker.md
@@ -24,7 +24,7 @@ Configure
 Copy example configuration files with following:
 
 ```sh
-cp .config/example.yml .config/default.yml
+cp .config/docker_example.yml .config/default.yml
 cp .config/docker_example.env .config/docker.env
 cp ./docker-compose.yml.example ./docker-compose.yml
 ```


### PR DESCRIPTION
In the instruction to copy the configuration, the correct Docker configuration "docker_example.yml" was not specified. Instead, the normal configuration "example.yml" was specified.

This causes problems because the normal config expects a database instance on the localhost, but with Docker it is reachable via the "db" hostname.