### PR TITLE
dedup "thread-mute" page link / "スレッドミュート" ページへのリンクの重複排除

### DIFF
--- a/src/.vuepress/config.ts
+++ b/src/.vuepress/config.ts
@@ -104,7 +104,6 @@ export default defineUserConfig<DefaultThemeOptions>({
                                     '/docs/features/follow',
                                     '/docs/features/pages',
                                     '/docs/features/theme',
-                                    '/docs/features/thread-mute',
                                     '/docs/features/widgets',
                                 ]
                             },
@@ -189,7 +188,6 @@ export default defineUserConfig<DefaultThemeOptions>({
                                     '/en/docs/features/follow',
                                     '/en/docs/features/pages',
                                     '/en/docs/features/theme',
-                                    '/en/docs/features/thread-mute',
                                     '/en/docs/features/widgets',
                                 ]
                             },
@@ -363,7 +361,6 @@ export default defineUserConfig<DefaultThemeOptions>({
                                     '/it/docs/features/follow',
                                     '/it/docs/features/pages',
                                     '/it/docs/features/theme',
-                                    '/it/docs/features/thread-mute',
                                     '/it/docs/features/widgets',
                                 ]
                             },


### PR DESCRIPTION
## Why
Currently "thread-mute" links in nav bar are duplicated.
現在、ナビゲーションバー内の「スレッドミュート」リンクが重複して存在しています

- https://github.com/misskey-dev/misskey-hub/blob/8f790cdc8d383f1132094d14a518e4b0aa2fba31/src/.vuepress/config.ts#L97-L107
- https://github.com/misskey-dev/misskey-hub/blob/8f790cdc8d383f1132094d14a518e4b0aa2fba31/src/.vuepress/config.ts#L182-L192
- https://github.com/misskey-dev/misskey-hub/blob/8f790cdc8d383f1132094d14a518e4b0aa2fba31/src/.vuepress/config.ts#L356-L366

## What

Deduplicate `'/docs/features/thread-mute'` link in `src/.vuepress/config.ts`
`src/.vuepress/config.ts` 内の `'/docs/features/thread-mute'` リンクの重複を排除


before | after
--- | ---
![スクリーンショット 2023-02-11 20 40 09](https://user-images.githubusercontent.com/26884355/218256148-b308cd02-db6c-4d0d-8088-e23e22a2f2fb.png) | ![スクリーンショット 2023-02-11 20 40 17](https://user-images.githubusercontent.com/26884355/218256084-80ce0d72-3662-4699-9cd1-53b82776b34f.png)
