### PR TITLE
Fix GitHub link overlaps the navigation bar

### DIFF
--- a/src/.vuepress/mitheme/src/client/layouts/Landing.vue
+++ b/src/.vuepress/mitheme/src/client/layouts/Landing.vue
@@ -48,7 +48,7 @@
 		<img v-parallax="2" src="/screenshot-desktop.png" class="screenshot desktop" alt="screenshot of Misskey in a PC browser">
 		<img v-parallax="3" src="/screenshot-mobile.png" class="screenshot mobile" alt="screenshot of Misskey in a mobile browser">
 		<img v-parallax="4" src="/ai.png" class="ai" alt="Ai-chan, Misskey's mascott">
-		<a href="https://github.com/misskey-dev/misskey" target="_blank" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="position: fixed; z-index: 10; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
+		<a href="https://github.com/misskey-dev/misskey" target="_blank" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; z-index: 10; top: var(--globalHeaderHeight); border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
 	</div>
 
 	<div class="key-features">
@@ -383,6 +383,7 @@ html {
 
 	> .top {
 		position: relative;
+    padding-top: var(--globalHeaderHeight);
 		height: 1200px;
 
 		> .container {
@@ -483,7 +484,7 @@ html {
 		> .dots1 {
 			position: absolute;
 			right: 900px;
-			top: 200px;
+      top: calc(200px + var(--globalHeaderHeight, 0px));
 			width: 300px;
 			height: 300px;
 			color: var(--c-brand);
@@ -494,7 +495,7 @@ html {
 		> .dots2 {
 			position: absolute;
 			right: 120px;
-			top: 500px;
+      top: calc(500px + var(--globalHeaderHeight, 0px));
 			width: 300px;
 			height: 300px;
 			color: var(--c-brand);
@@ -505,7 +506,7 @@ html {
 		> .screenshot.desktop {
 			position: absolute;
 			right: 300px;
-			top: 128px;
+      top: calc(128px + var(--globalHeaderHeight, 0px));
 			width: 800px;
 			border-radius: 10px;
 			box-shadow: 2px 2px 32px rgba(0, 0, 0, 0.1);
@@ -516,7 +517,7 @@ html {
 		> .screenshot.mobile {
 			position: absolute;
 			right: 650px;
-			top: 400px;
+      top: calc(400px + var(--globalHeaderHeight, 0px));
 			height: 400px;
 			border-radius: 10px;
 			box-shadow: 2px 2px 32px rgba(0, 0, 0, 0.1);
@@ -527,7 +528,7 @@ html {
 		> .ai {
 			position: absolute;
 			right: 130px;
-			top: 128px;
+      top: calc(128px + var(--globalHeaderHeight, 0px));
 			height: 900px;
 		}
 


### PR DESCRIPTION
#195 であげた提案を実装しました。

また、スマホで表示した場合、常時右上にリンクがあると少し邪魔に感じる場面があったので、固定しないように変更しています。

### デスクトップ表示

![pc](https://user-images.githubusercontent.com/44780846/220130675-dfb3128e-2e19-47ad-aba4-c0d6b62883b3.gif)

### スマホ表示

![mobile](https://user-images.githubusercontent.com/44780846/220130469-32da8894-068a-4a81-9b43-0afa3b44f73d.gif)
