### PR TITLE
fix: fixed JSON format in params and response

### DIFF
--- a/src/.vuepress/components/MkApiConsole.vue
+++ b/src/.vuepress/components/MkApiConsole.vue
@@ -57,7 +57,7 @@ if (props.def.req) {
 			null;
 	}
 }
-params.value = JSON5.stringify(endpointBody, null, 2);
+params.value = JSON.stringify(endpointBody, null, 2);
 
 const endpoint = ref(props.name);
 const host = ref(localStorage.getItem('host') ?? '');
@@ -76,9 +76,10 @@ watch(token, () => {
 function request() {
 	const promise = new Promise((resolve, reject) => {
 		const data = {
-			...params.value,
+			...JSON5.parse(params.value),
 			i: token.value && token.value.trim() !== '' ? token.value : undefined,
 		};
+
 		fetch(`https://${host.value}/api/${endpoint.value}`, {
 			method: 'POST',
 			body: JSON.stringify(data),
@@ -105,7 +106,8 @@ function request() {
 
 async function onSubmit() {
 	const _res = await request();
-	res.value = JSON5.stringify(_res, null, '\t');
+
+	res.value = JSON.stringify(_res, null, '\t');
 }
 </script>
 


### PR DESCRIPTION
こんにちは。

APIコンソールのParamsフィールドとResponseフィールドに出力されるJSONが標準的なフォーマットではないので修正しました。

例えば、Paramsフィールドで以下のように出力されていたのを:

```json
{
  limit: 0,
  sinceId: '',
  untilId: '',
  following: false,
  unreadOnly: false,
  markAsRead: false,
  includeTypes: [],
  excludeTypes: [],
}
```

次のように出力されるように修正しました。

```json
{
  "limit": 0,
  "sinceId": "",
  "untilId": "",
  "following": false,
  "unreadOnly": false,
  "markAsRead": false,
  "includeTypes": [],
  "excludeTypes": []
}
```

Responseフィールドに関しても上記のJSONフォーマットで出力されるように修正しました。

標準的なフォーマットでJSONを出力することで、ユーザーが使用するプログラミング言語やプラットフォームに依存せず出力を再利用可能です。

一部 #193 と修正範囲が重複するかもしれません。