### PR TITLE
fix: fixed to output response error

### DIFF
--- a/src/.vuepress/components/MkApiConsole.vue
+++ b/src/.vuepress/components/MkApiConsole.vue
@@ -95,7 +95,7 @@ function request() {
 			} else if (res.status === 204) {
 				resolve();
 			} else {
-				reject(body.error);
+				resolve(body.error);
 			}
 		}).catch(reject);
 	});


### PR DESCRIPTION
こんにちは。

昨日作成したPR(#208)と関連してMisskey APIのレスポンスエラーを出力するように修正しました。

リクエスト成功時のJSONだけではなく、
リクエストが失敗した場合のJSONも確認できたほうが開発者にとって親切だと感じます。