### PR TITLE
fix: fixed endpoint field as read-only

### DIFF
--- a/src/.vuepress/components/MkApiConsole.vue
+++ b/src/.vuepress/components/MkApiConsole.vue
@@ -9,7 +9,7 @@
 					</el-input>
 				</el-form-item>
 				<el-form-item label="Endpoint" :rules="[{ required: true }]">
-					<el-input v-model="endpoint" placeholder="foo/bar">
+					<el-input v-model="endpoint" placeholder="foo/bar" readonly="true">
 						<template #prepend>https://{{ host }}/api/</template>
 					</el-input>
 				</el-form-item>


### PR DESCRIPTION
こんにちは。

#206 に関してAPIコンソールのエンドポイント項目を読み取り専用とするように修正しました。

もしリクエストパラメータをURLに含めるエンドポイントがある場合は、
Paramsのようなクエリパラメータ用の入力欄を用意すべきだと感じます。