### PR TITLE
Add DriveFile (entity)

### DIFF
--- a/src/docs/api/common.json5
+++ b/src/docs/api/common.json5
@@ -60,6 +60,69 @@
 				},
 			},
 		},
+		DriveFile: {
+			type: 'object',
+			properties: {
+				id: {
+					type: 'string',
+				},
+				createdAt: {
+					type: 'string',
+				},
+				name: {
+					type: 'string',
+				},
+				md5: {
+					type: 'string',
+				},
+				size: {
+					type: 'integer',
+				},
+				isSensitive: {
+					type: 'boolean',
+				},
+				blurhash: {
+					type: 'string',
+				},
+				properties: {
+					type: 'object',
+					properties: {
+						width: {
+							type: 'integer',
+						},
+						height: {
+							type: 'integer',
+						},
+					}
+				},
+				url: {
+					type: 'string'
+				},
+				thumbnailUrl: {
+					type: 'string',
+				},
+				comment: {
+					type: 'string',
+					nullable: true,
+				},
+				folderId: {
+					type: 'string',
+					nullable: true,
+				},
+				folder: {
+					type: 'string',
+					nullable: true,
+				},
+				userId: {
+					type: 'string',
+					nullable: true,
+				},
+				user: {
+					type: 'string',
+					nullable: true,
+				},
+			}
+		}
 	},
 	errors: {
 		'1384574d-a912-4b81-8601-c7b1c4085df1': {


### PR DESCRIPTION
はじめまして。

## 変更点

エンドポイント一覧の [drive/files](https://misskey-hub.net/docs/api/endpoints/drive/files.html) などに関係するレスポンスのエンティティがリンク切れでしたので common.json5 に追加しました。

作成されたページは http://{host}:{port}/docs/api/entity/drivefile.html に生成されます。

## 生成結果

![image](https://user-images.githubusercontent.com/58127312/221394878-4288af13-cf29-4e3d-a422-6bc89dd87a91.png)

## 問題点

[drive/files](https://misskey-hub.net/docs/api/endpoints/drive/files.html) のレスポンスの DriveFile へのリンクは、`drive-file.html` になっていましたが、どのようにリダイレクトさせるのかの Misskey Hub のルールがわからなかったので、ドラフト扱いで PR します。
