### PR TITLE
package.jsonにnodeおよびnpmの必須バージョンを明記

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "misskey-hub",
   "version": "0.0.0",
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.6.0"
+  },
   "scripts": {
     "dev": "vuepress dev src",
     "build": "vuepress build src"


### PR DESCRIPTION
日々お世話になっております。
package.jsonにnodeおよびnpmの必須バージョンを記載する対応を行いました。

## なぜ？

- 複数バージョンあるnodeのうち、何を使えば良いのか初見で分からなかった
- ltsのv16ではMisskeyHubを起動できず、v18では起動することが出来たので明記したほうが良いのではと考えた
- maintenanceとはいえまだ生きているLTSが複数バージョンある（参考：https://endoflife.date/nodejs）

## 何をした？

package.jsonにengines項目を追記し、そこに最低限必要なnodeおよびnpmのバージョンを記載した。

- nodeのバージョン
`18.0.0`としているが、これはv16、v17、v18とnodeのバージョンを切り替えてMisskeyHubの起動を試行し、
トップページの表示に成功したバージョンを指定している。
- npmのバージョン
nodeのバージョンを切り替えた際にセットで入ってくるもののバージョンをそのまま指定した。

## 影響範囲
開発者自身のみ。プロダクトやユーザ影響は無い。
開発者各位はローカルで起動に成功しているはずで、起動に成功している＝node v18.0.0以上を使っているはず。
npmの実行時にバージョンの確認が走るようになるだけで、生成物などには影響はないと考える。

適合したバージョンを使用していないと以下のような警告が出るようになる
```
osamu@localhost:~/work/misskey-hub$ npm install
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'misskey-hub@0.0.0',
npm WARN EBADENGINE   required: { node: '>=18.0.0', npm: '>=8.6.0' },
npm WARN EBADENGINE   current: { node: 'v16.19.1', npm: '8.19.3' }
npm WARN EBADENGINE }
```