### PR TITLE
APIConsoleにて必須項目が入力されているのにも関わらずバリデーションエラーが発生してしまう問題等の修正

### DIFF
--- a/src/.vuepress/components/MkApiConsole.vue
+++ b/src/.vuepress/components/MkApiConsole.vue
@@ -3,12 +3,12 @@
 	<el-collapse v-model="expands">
 		<el-collapse-item title="API Console" name="console">
 			<el-form :model="form" label-width="120px">
-				<el-form-item label="Host" :rules="[{ required: true }]">
+				<el-form-item label="Host" prop="host" :rules="[{ required: true }]">
 					<el-input v-model="host" placeholder="misskey.example.com">
 						<template #prepend>https://</template>
 					</el-input>
 				</el-form-item>
-				<el-form-item label="Endpoint" :rules="[{ required: true }]">
+				<el-form-item label="Endpoint" prop="endpoint" :rules="[{ required: true }]">
 					<el-input v-model="endpoint" placeholder="foo/bar">
 						<template #prepend>https://{{ host }}/api/</template>
 					</el-input>
@@ -65,6 +65,12 @@ const token = ref(localStorage.getItem('token') ?? '');
 const res = ref(null);
 const expands = ref([]);
 
+// for validation
+const form = ref({
+	host,
+	endpoint,
+})
+
 watch(host, () => {
 	localStorage.setItem('host', host.value)
 });
@@ -76,7 +82,7 @@ watch(token, () => {
 function request() {
 	const promise = new Promise((resolve, reject) => {
 		const data = {
-			...params.value,
+			...JSON5.parse(params.value),
 			i: token.value && token.value.trim() !== '' ? token.value : undefined,
 		};
 		fetch(`https://${host.value}/api/${endpoint.value}`, {
@@ -95,7 +101,7 @@ function request() {
 			} else if (res.status === 204) {
 				resolve();
 			} else {
-				reject(body.error);
+				resolve(body.error);
 			}
 		}).catch(reject);
 	});


### PR DESCRIPTION
日々お世話になっております。
APIConsoleにて必須項目が入力されているのにも関わらずバリデーションエラーが発生してしまう問題およびリクエストに失敗する問題の対応を行いました。

## なぜ？

- #205 に記載されている通り

## 何をした？

- #205 の原因を修正
el-formにバインドしている変数formが定義されておらず、async-validatorまで値が到達していなかった。
バリデーション対象のhost、endpointを持たせた変数formを定義し、バリデーション処理が動作するように修正した。
（6、11、64-73行目の修正が該当）
- リクエストのbodyが意図せぬ形になってしまっているのを修正。
文字列であるparams.valueにスプレッド構文を当ててしまっていたため、直前にObject化する処理を追加。
（85行目の修正が該当）
- リクエストエラー時、エラー内容をレスポンス表示部に表示できてなかったのを修正。
処理の意図を見るに、エラーレスポンスの内容をフォームに出したかったのだと思われるが、
request()の呼び出し元でawaitしている＋body.errorの返し方がreject()の組み合わせで例外となってしまっており、
フォームにエラー内容を出す前に処理を抜けてしまっていた。
（104行目の修正が該当）

※1番目以外の修正は不要であれば、お手数ですがその旨お申し付けください。該当行数のみ修正を取り消します

## 影響範囲
MisskeyHubのAPIリファレンスを参照する方々。
または、APIConsoleを埋め込んでいるページすべて
