### PR TITLE
Fix a mistake on manual.md

### DIFF
--- a/src/en/docs/install/manual.md
+++ b/src/en/docs/install/manual.md
@@ -92,6 +92,7 @@ If you're on Debian, you will need to install the `build-essential`, `python` pa
 	create database misskey with encoding = 'UTF8';
 	create user misskey with encrypted password '{YOUR_PASSWORD}';
 	grant all privileges on database misskey to misskey;
+	alter database misskey owner to misskey;
 	\q
 	```
 


### PR DESCRIPTION
I followed the guide to manually install my Misskey instance and found a mistake on the document.

Here is the detail of the mistake:

misskey@vps:~/misskey$ pnpm run init

misskey@13.12.2 init /home/misskey/misskey
pnpm migrate

misskey@13.12.2 migrate /home/misskey/misskey
cd packages/backend && pnpm migrate

backend@ migrate /home/misskey/misskey/packages/backend
pnpm typeorm migration:run -d ormconfig.js

query: SELECT * FROM current_schema()
query: SELECT version();
query: SELECT * FROM "information_schema"."tables" WHERE "table_schema" = 'public' AND "table_name" = 'migrations'
query: CREATE TABLE "migrations" ("id" SERIAL NOT NULL, "timestamp" bigint NOT NULL, "name" character varying NOT NULL, CONSTRAINT "PK_8c82d7f526340ab734260ea46be" PRIMARY KEY ("id"))
query failed: CREATE TABLE "migrations" ("id" SERIAL NOT NULL, "timestamp" bigint NOT NULL, "name" character varying NOT NULL, CONSTRAINT "PK_8c82d7f526340ab734260ea46be" PRIMARY KEY ("id"))
error: error: permission denied for schema public
Error during migration run:
QueryFailedError: permission denied for schema public
    at PostgresQueryRunner.query (/home/misskey/misskey/node_modules/.pnpm/typeorm@0.3.16_ioredis@5.3.2_pg@8.10.0/node_modules/typeorm/driver/postgres/PostgresQueryRunner.js:211:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async PostgresQueryRunner.executeQueries (/home/misskey/misskey/node_modules/.pnpm/typeorm@0.3.16_ioredis@5.3.2_pg@8.10.0/node_modules/typeorm/query-runner/BaseQueryRunner.js:424:13)
    at async PostgresQueryRunner.createTable (/home/misskey/misskey/node_modules/.pnpm/typeorm@0.3.16_ioredis@5.3.2_pg@8.10.0/node_modules/typeorm/driver/postgres/PostgresQueryRunner.js:410:9)
    at async MigrationExecutor.createMigrationsTableIfNotExist (/home/misskey/misskey/node_modules/.pnpm/typeorm@0.3.16_ioredis@5.3.2_pg@8.10.0/node_modules/typeorm/migration/MigrationExecutor.js:351:13)
    at async MigrationExecutor.executePendingMigrations (/home/misskey/misskey/node_modules/.pnpm/typeorm@0.3.16_ioredis@5.3.2_pg@8.10.0/node_modules/typeorm/migration/MigrationExecutor.js:129:9)
    at async DataSource.runMigrations (/home/misskey/misskey/node_modules/.pnpm/typeorm@0.3.16_ioredis@5.3.2_pg@8.10.0/node_modules/typeorm/data-source/DataSource.js:260:35)
    at async Object.handler (/home/misskey/misskey/node_modules/.pnpm/typeorm@0.3.16_ioredis@5.3.2_pg@8.10.0/node_modules/typeorm/commands/MigrationRunCommand.js:68:13) {
  query: 'CREATE TABLE "migrations" ("id" SERIAL NOT NULL, "timestamp" bigint NOT NULL, "name" character varying NOT NULL, CONSTRAINT "PK_8c82d7f526340ab734260ea46be" PRIMARY KEY ("id"))',
  parameters: undefined,
  driverError: error: permission denied for schema public
      at Parser.parseErrorMessage (/home/misskey/misskey/node_modules/.pnpm/pg-protocol@1.6.0/node_modules/pg-protocol/dist/parser.js:287:98)
      at Parser.handlePacket (/home/misskey/misskey/node_modules/.pnpm/pg-protocol@1.6.0/node_modules/pg-protocol/dist/parser.js:126:29)
      at Parser.parse (/home/misskey/misskey/node_modules/.pnpm/pg-protocol@1.6.0/node_modules/pg-protocol/dist/parser.js:39:38)
      at Socket.<anonymous> (/home/misskey/misskey/node_modules/.pnpm/pg-protocol@1.6.0/node_modules/pg-protocol/dist/index.js:11:42)
      at Socket.emit (node:events:513:28)
      at addChunk (node:internal/streams/readable:324:12)
      at readableAddChunk (node:internal/streams/readable:297:9)
      at Readable.push (node:internal/streams/readable:234:10)
      at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
    length: 99,
    severity: 'ERROR',
    code: '42501',
    detail: undefined,
    hint: undefined,
    position: '14',
    internalPosition: undefined,
    internalQuery: undefined,
    where: undefined,
    schema: undefined,
    table: undefined,
    column: undefined,
    dataType: undefined,
    constraint: undefined,
    file: 'aclchk.c',
    line: '3650',
    routine: 'aclcheck_error'
  },
  length: 99,
  severity: 'ERROR',
  code: '42501',
  detail: undefined,
  hint: undefined,
  position: '14',
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'aclchk.c',
  line: '3650',
  routine: 'aclcheck_error'
}
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.

The solution is to set the database user as the database owner.