### PR TITLE
fix: Misskey install shell script v3.0.0

### DIFF
--- a/src/docs/install/bash.md
+++ b/src/docs/install/bash.md
@@ -47,7 +47,7 @@ sudo apt update; sudo apt full-upgrade -y; sudo reboot
 ### 3. インストールをはじめる
 SSHを接続しなおして、Misskeyのインストールを始めましょう。
 
-ただ、インストール前に[Tips](#Tips)を読むことを強くお勧めします。
+ただ、インストール前に[Tips](#tips)を読むことを強くお勧めします。
 
 ```
 wget https://raw.githubusercontent.com/joinmisskey/bash-install/main/ubuntu.sh -O ubuntu.sh; sudo bash ubuntu.sh


### PR DESCRIPTION
Markdownのh1へのリンク指定は、case sensitiveで指定するようです。
Tipsへのリンクを修正しました。