### PR TITLE
Update ubuntu-manual.md: add pnpm install options `--prod` and `--ignore-scripts`

### DIFF
--- a/src/docs/install/ubuntu-manual.md
+++ b/src/docs/install/ubuntu-manual.md
@@ -356,7 +356,7 @@ git checkout master
 必要なnpmパッケージをインストール。
 
 ```sh
-NODE_ENV=production pnpm install --frozen-lockfile
+NODE_ENV=production pnpm install --frozen-lockfile --ignore-scripts --prod
 ```
 
 ## Misskeyを設定する


### PR DESCRIPTION
- `--prod`
この工程では`devDependencies `は不要のため
- `--ignore-scripts`
Arch Linux環境にて、`re2`のinstall scriptが`ELIFECYCLE`エラーとなりました
install scriptの実行は不要と思いますので、オプション追加を提案します