### PR TITLE
Repair linking of isCat

### DIFF
--- a/src/ns.md
+++ b/src/ns.md
@@ -80,6 +80,8 @@ Misskey handles these kinds of messages specially, e.g. it will apply different 
 
 This field can only take the value of `true` (or be absent).
 
+<a name="isCat" />
+
 ## `isCat`
 
 - compact IRI: `misskey:isCat`


### PR DESCRIPTION
Currently https://misskey-hub.net/ns#isCat does not take you directly to the definition of isCat. This pull request fixes this, by adding an additional anchor.

Currently, the working link would be https://misskey-hub.net/ns#iscat, which is not the URI used.