### PR TITLE
Add channel schema

### DIFF
--- a/src/docs/api/common.json5
+++ b/src/docs/api/common.json5
@@ -60,6 +60,62 @@
 				},
 			},
 		},
+		channel: {
+			type: 'object',
+			properties: {
+				id: {
+					type: 'string',
+				},
+				createAt: {
+					type: 'string',
+				},
+				lastNotedAt: {
+					type: 'string',
+				},
+				name: {
+					type: 'string',
+				},
+				description: {
+					type: 'string',
+				},
+				bannerUrl: {
+					type: 'string',
+				},
+				isArchived: {
+					type: 'boolean',
+				},
+				notedCount: {
+					type: 'number',
+				},
+				usersCount: {
+					type: 'number',
+				},
+				isFollowing: {
+					type: 'boolean',
+				},
+				isFavorite: {
+					type: 'boolean',
+				},
+				userId: {
+					type: 'string',
+				},
+				pinnedNoteIds: {
+					type: 'array',
+					items: {
+						type: 'string',
+					},
+				},
+				color: {
+					type: 'string',
+				},
+				isSensitive: {
+					type: 'boolean',
+				},
+				allowRenoteToExternal: {
+					type: 'boolean',
+				},
+			}
+		}
 	},
 	errors: {
 		'1384574d-a912-4b81-8601-c7b1c4085df1': {


### PR DESCRIPTION
## やったこと
https://misskey-hub.net/docs/api/endpoints/channels/show.html を確認したときに、そこからの Channel 型への[リンク先](https://misskey-hub.net/docs/api/entity/channel.html)が 404 だったので、 `channel` の型情報を追加しました。

## 調べたこと
過去に同様の追加のPR がなかったのですが、 https://github.com/misskey-dev/misskey-hub/blob/6b9d9eb2a38692931481ab62fe5718d7f5b488f1/src/.vuepress/generate-endpoint-pages.ts#L103-L108 を見て自動生成しているようだったので `src/docs/api/common.json5` を編集しました。

型の情報は https://github.com/misskey-dev/misskey/blob/30bb24d18c7d3f214114207dfe493ca9a9fe1faf/packages/backend/src/models/json-schema/channel.ts を参考にしました。

既存の型情報を見るに、 nullable などの情報は書かれていなかったので、書いていません。
https://github.com/misskey-dev/misskey-hub/blob/6b9d9eb2a38692931481ab62fe5718d7f5b488f1/src/docs/api/common.json5#L34-L62

## 確認したこと
- 手元で起動し、 `http://localhost:8080/docs/api/entity/channel.html` で問題なく表示されていました。

---

レビューお願いします 🙏 

https://github.com/misskey-dev/misskey-hub-next/issues/6 も読んだのですが、全体の方針がわからなかったので一旦PRを出しましたが、別にプロジェクトが走ってたらクローズお願いします
